### PR TITLE
Added pattern for aws resources

### DIFF
--- a/iocsearcher/data/patterns.ini
+++ b/iocsearcher/data/patterns.ini
@@ -214,6 +214,6 @@ validate = True
 pattern = \b(T[0-9]{4}([.][0-9]{3})?)\b
 
 [awsResource]
-pattern = arn:(aws|aws-cn|aws-us-gov):([a-zA-Z0-9-]+):([a-zA-Z0-9-]*):(\d{12}|):([^:/]+)([:/].*)
+pattern = arn:([a-z0-9][-.a-z0-9]{0,62}):([a-zA-Z0-9-]+){0,62}:([a-zA-Z0-9-]+){0,62}:(\d{12})?:([^/].{0,1023})
 flags= IGNORECASE
 validate = True

--- a/iocsearcher/data/patterns.ini
+++ b/iocsearcher/data/patterns.ini
@@ -213,3 +213,7 @@ validate = True
 [ttp]
 pattern = \b(T[0-9]{4}([.][0-9]{3})?)\b
 
+[awsResource]
+pattern = arn:(aws|aws-cn|aws-us-gov):([a-zA-Z0-9-]+):([a-zA-Z0-9-]*):(\d{12}|):([^:/]+)([:/].*)
+flags= IGNORECASE
+validate = True


### PR DESCRIPTION
Some tests available in this [link](https://regex101.com/r/C8ysBc/4)

The official documentation contains a [pattern](https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_ArnResource.html), but it doesn't match cases like arn:aws:s3:::my-s3-bucket

