### PR TITLE
Add pattern for Microsoft Azure resources

### DIFF
--- a/iocsearcher/data/patterns.ini
+++ b/iocsearcher/data/patterns.ini
@@ -214,6 +214,6 @@ validate = True
 pattern = \b(T[0-9]{4}([.][0-9]{3})?)\b
 
 [awsResource]
-pattern = arn:(aws|aws-cn|aws-us-gov):([a-zA-Z0-9-]+):([a-zA-Z0-9-]*):(\d{12}|):([^:/]+)([:/].*)
+pattern = arn:([a-z0-9][-.a-z0-9]{0,62}):([a-zA-Z0-9-]+){0,62}:([a-zA-Z0-9-]+){0,62}:(\d{12})?:([^/].{0,1023})
 flags= IGNORECASE
 validate = True

--- a/iocsearcher/data/patterns.ini
+++ b/iocsearcher/data/patterns.ini
@@ -213,8 +213,8 @@ validate = True
 [ttp]
 pattern = \b(T[0-9]{4}([.][0-9]{3})?)\b
 
-[googleCloudResource]
-pattern = //([a-zA-Z0-9-]+)\.googleapis\.com/([a-zA-Z0-9\-_/]+/)*([a-zA-Z0-9-_]+)$
+[azureResource]
+pattern = (https://management.azure.com/subscriptions|/subscriptions)/([a-f0-9\-]{36})/resourceGroups/([a-zA-Z0-9\-]+)/providers/([a-zA-Z0-9\.]+)/([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-]+)(/.*)?
 flags= IGNORECASE
 validate = True
 

--- a/iocsearcher/data/patterns.ini
+++ b/iocsearcher/data/patterns.ini
@@ -213,7 +213,7 @@ validate = True
 [ttp]
 pattern = \b(T[0-9]{4}([.][0-9]{3})?)\b
 
-[awsResource]
-pattern = arn:([a-z0-9][-.a-z0-9]{0,62}):([a-zA-Z0-9-]+){0,62}:([a-zA-Z0-9-]+){0,62}:(\d{12})?:([^/].{0,1023})
+[googleCloudResource]
+pattern = //([a-zA-Z0-9-]+)\.googleapis\.com/([a-zA-Z0-9\-_/]+/)*([a-zA-Z0-9-_]+)$
 flags= IGNORECASE
 validate = True

--- a/iocsearcher/data/patterns.ini
+++ b/iocsearcher/data/patterns.ini
@@ -217,3 +217,4 @@ pattern = \b(T[0-9]{4}([.][0-9]{3})?)\b
 pattern = //([a-zA-Z0-9-]+)\.googleapis\.com/([a-zA-Z0-9\-_/]+/)*([a-zA-Z0-9-_]+)$
 flags= IGNORECASE
 validate = True
+

--- a/iocsearcher/data/patterns.ini
+++ b/iocsearcher/data/patterns.ini
@@ -213,3 +213,7 @@ validate = True
 [ttp]
 pattern = \b(T[0-9]{4}([.][0-9]{3})?)\b
 
+[awsResource]
+pattern = arn:(aws|aws-cn|aws-us-gov):([a-zA-Z0-9-]+):([a-zA-Z0-9-]*):(\d{12}|):([^:/]+)([:/].*)
+flags= IGNORECASE
+validate = True


### PR DESCRIPTION
Tests available on https://regex101.com/r/mt5rVt/3

- A resource might start with https://management.azure.com/subscriptions or just /subscriptions
- Assuming resource identifiers follow a specific format based on the subscription, resource group, and provider hierarchy https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/overview